### PR TITLE
Make Renovate run once per week

### DIFF
--- a/web-pillar-repositories.json
+++ b/web-pillar-repositories.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "schedule": ["on Monday at 04:00"],
   "automergeSchedule": ["at 10am on Monday except on 25th of December in 2023 and 1st of January 2024 and 1st of April 2024 and 20th of May 2024 and 19th of August 2024"],
   "description": "Default Renovate configuration for Web Pillar repositories",
   "extends": [


### PR DESCRIPTION
currently Renovate opens PRs multiple times a week, which results in some noise and engineers feeling overwhelmed by the amount of PRs (e.g. we don't need to upgrade the GCP PubSub emulator used in local dev multiple times a week 😅)

Let's run Renovate once a week.

https://docs.renovatebot.com/noise-reduction/