### PR TITLE
Do not opt out auto-merge for vuln alerts

### DIFF
--- a/web-pillar-repositories.json
+++ b/web-pillar-repositories.json
@@ -90,7 +90,6 @@
   "rebaseWhen": "auto",
   "transitiveRemediation": true,
   "vulnerabilityAlerts": {
-    "automerge": false,
     "enabled": true,
     "labels": ["website-security"]
   }


### PR DESCRIPTION
we need to check how this plays out but ideally this would let the other rules apply what to auto-merge. (And we could auto-merge e.g. minor Go dep updates even if it was opened because of a vulnerability alert.)