### PR TITLE
Add 14-day minimumReleaseAge to web pillar Renovate config

### DIFF
--- a/web-pillar-repositories.json
+++ b/web-pillar-repositories.json
@@ -8,6 +8,7 @@
   ],
   "labels": ["renovate", "renovate-web-pillar-repositories"],
   "automergeType": "pr",
+  "minimumReleaseAge": "14 days",
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
## Summary
- Adds `"minimumReleaseAge": "14 days"` to `web-pillar-repositories.json` so new dependency releases sit for two weeks before Renovate proposes them, giving the team time to research them.
- Vulnerability alerts bypass `minimumReleaseAge` by default in Renovate, so security updates are not delayed. See [Renovate docs](https://docs.renovatebot.com/key-concepts/minimum-release-age/#what-happens-to-security-updates).

## Test plan
- [ ] Confirm Renovate picks up the new config on the next scheduled run for a web pillar repo
- [ ] Verify a non-security update PR is held until the release is 14+ days old
- [ ] Verify a vulnerability alert PR still opens immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)